### PR TITLE
Update dependencies.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -5,7 +5,8 @@ const Util = require('util');
 const Config = require('../config');
 const Server = require('./server');
 
-Server.start((err) => {
+Server.start()
+.then((err) => {
   if (err) {
     return Util.log('Error:', err.message);
   };

--- a/app/plugins/index.js
+++ b/app/plugins/index.js
@@ -3,8 +3,8 @@
 const Util = require('util');
 
 exports.register = (server, options, next) => {
-  server.register([
-  ], (err) =>  {
+  server.register([])
+  .then((err) =>  {
     /* $lab:coverage:off$ */
     if (err) {
       throw err;

--- a/app/server.js
+++ b/app/server.js
@@ -25,7 +25,8 @@ server.connection({
 });
 
 // register plugins
-server.register({ register: require('./plugins') }, (err) => {
+server.register({ register: require('./plugins') })
+.then((err) => {
   /* $lab:coverage:off$ */
   if (err) {
     throw err;

--- a/package.json
+++ b/package.json
@@ -38,14 +38,14 @@
   },
   "homepage": "https://github.com/oparamo/apollo-api#readme",
   "dependencies": {
-    "boom": "3.0.0",
-    "hapi": "11.1.2",
-    "joi": "7.0.1"
+    "boom": "3.1.1",
+    "hapi": "12.1.0",
+    "joi": "7.1.0"
   },
   "devDependencies": {
-    "code": "2.0.1",
+    "code": "2.1.0",
     "eslint": "1.10.3",
-    "eslint-config-hapi": "8.0.0",
+    "eslint-config-hapi": "8.0.1",
     "eslint-plugin-hapi": "4.0.0",
     "generate-changelog": "1.0.0",
     "husky": "0.10.2",


### PR DESCRIPTION
- Upgrade outdated npm dependencies.
- Upgrade to new Hapi version.
- Use promises instead of callbacks with Hapi.
